### PR TITLE
Fix bug with Status command when running cmd on files with just Merge status

### DIFF
--- a/lib/tfs/status.js
+++ b/lib/tfs/status.js
@@ -43,7 +43,7 @@ var _status = function(itemspec, options, callback) {
     var line,
         lineRegexp = /(.+)\r\n/g,
         lineStatus,
-        lineStatusRegexp = /(.*)(add|delete|edit|rename)(.*)/,
+        lineStatusRegexp = /(.*)(add|delete|edit|rename|merge)(.*)/,
         summaryRegexp = /change\(s\)/,
         status = {
           detectedChanges: [],


### PR DESCRIPTION
Usually, a merge from a different TFS branch will result in a "merge, edit" status, so the regex would catch it, but occasionally if one file in a set had an equivalent change on the branch you're merging in to, it results in a "merge" status only. Calling TFS Status is part of our build process, and we would encounter the following error in the above circumstance:
```
C:\[project path]\node_modules\tfs\lib\tfs\status.js:61
3>              fileName: lineStatus[1].trim(),
3>                                  ^
3>  
3>  TypeError: Cannot read property '1' of null
3>      at newCallback (C:\[project path]\node_modules\tfs\lib\tfs\status.js:61:33)
3>      at ChildProcess.<anonymous> (C:\[project path]\node_modules\tfs\lib\utils\tf.js:59:7)
3>      at emitTwo (events.js:106:13)
3>      at ChildProcess.emit (events.js:191:7)
3>      at maybeClose (internal/child_process.js:852:16)
3>      at Socket.<anonymous> (internal/child_process.js:323:11)
3>      at emitOne (events.js:96:13)
3>      at Socket.emit (events.js:188:7)
3>      at Pipe._handle.close [as _onclose] (net.js:492:12)
 ```
This change fixes our error.