### PR TITLE
VS2017 support

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -42,6 +42,30 @@ function buildSettings() {
       tfPath = '/Common7/IDE/TF.exe';
 
   switch (true) {
+    case fileExists(pf32Path + '/Microsoft Visual Studio/2017/Enterprise', true):
+      settings = {
+        tfPath: pf32Path + '/Microsoft Visual Studio/2017/Enterprise/Common7/IDE/CommonExtensions/Microsoft/TeamFoundation/Team Explorer/TF.exe',
+        vsArchitecture: 32,
+        vsVersion: 2017
+      };
+      break;
+
+    case fileExists(pf32Path + '/Microsoft Visual Studio/2017/Professional', true):
+      settings = {
+        tfPath: pf32Path + '/Microsoft Visual Studio/2017/Professional/Common7/IDE/CommonExtensions/Microsoft/TeamFoundation/Team Explorer/TF.exe',
+        vsArchitecture: 32,
+        vsVersion: 2017
+      };
+      break;
+
+    case fileExists(pf32Path + '/Microsoft Visual Studio/2017/Community', true):
+      settings = {
+        tfPath: pf32Path + '/Microsoft Visual Studio/2017/Community/Common7/IDE/CommonExtensions/Microsoft/TeamFoundation/Team Explorer/TF.exe',
+        vsArchitecture: 32,
+        vsVersion: 2017
+      };
+      break;
+
     case fileExists(pf64Path + '/Microsoft Visual Studio 14.0' + tfPath):
       settings = {
         tfPath: pf64Path + '/Microsoft Visual Studio 14.0' + tfPath,


### PR DESCRIPTION
This adds the ability to find `TF.exe` in a Visual Studio 2017 install.

For VS2017, Microsoft changed the location on disk a bit, it's now at `<Program Files>\Microsoft Visual Studio\<Year>`. 